### PR TITLE
Fix table formatting of fares.json

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -559,7 +559,6 @@ The following fields are all attributes within the main "data" object for this f
 
 Field Name | Presence | Type | Description
 ---|---|---|---
-
 `fares` | REQUIRED | Array | Array that contains one object per fare defintion as defined below.
 \-&nbsp;`fare_id` | REQUIRED | ID | Unique identifier of the fare.
 \-&nbsp;`currency` | REQUIRED | Currency code | The currency of the fare.


### PR DESCRIPTION
Remove extra blank line to make fares.json table render correctly in markdown.
I did the edit in github directly; not sure why it removed and replaced the last line, but looks like a no-op and still renders correctly.