### PR TITLE
Remove `purchase_url`

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -266,7 +266,7 @@ Field Name | Presence | Type | Description
     "short_name": "Micro",
     "operator": "MicroTransit, Inc",
     "url": "https://www.example.com",
-    "purchase_url": "https://www.example.com",
+    "subscribe_url": "https://www.example.com",
     "start_date": "20100610",
     "phone_number": "+18005551234",
     "email": "customerservice@example.com",

--- a/schema/system_information.json
+++ b/schema/system_information.json
@@ -45,9 +45,6 @@
         "subscribe_url": {
           "type": "string"
         },
-        "purchase_url": {
-          "type": "string"
-        },
         "start_date": {
           "type": "string"
         },


### PR DESCRIPTION
Examples seem incorrect - I believe this is supposed to be `subscribe_url` everywhere per the [system_information description](https://github.com/GOFS-lite/GOFS-lite/blob/main/reference.md#system_informationjson)