### PR TITLE
Minor improvement to `service_brands.json`'s example

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -313,7 +313,7 @@ Field Name | Presence | Type | Description
       },
       {
         "brand_id": "shared_ride",
-        "brand_name": "Large Ride",
+        "brand_name": "Shared Ride",
         "brand_color": "1C7F49",
         "brand_text_color": "FFFFFF",
       }


### PR DESCRIPTION
Hi everyone. Reading through the examples, I found that the name "Large Ride" was repeated for two different service brands. I think "Shared Ride" would make more sense here (based on the structure of the previous service brands in the same example).

Let me know what you think!