### PR TITLE
Add `ttl`, `version`, `last_updated` and `data` properties to `zones`' schema

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -390,6 +390,7 @@ Field Name | Presence | Type | Description
         {
           "type": "Feature",
           "zone_id": "zoneA",
+          "properties": {},
           "geometry": {
             "type": "Polygon",
             "coordinates": [

--- a/schema/zones.json
+++ b/schema/zones.json
@@ -1,335 +1,237 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://geojson.org/schema/FeatureCollection.json",
-  "title": "GeoJSON FeatureCollection",
+  "$id": "https://github.com/GOFS-lite/GOFS-lite/blob/main/reference.md#zonesjson",
+  "description": "Geographically defines zones where on-demand services are available to the riders.",
   "type": "object",
-  "required": [
-    "type",
-    "features"
-  ],
   "properties": {
-    "type": {
+    "last_updated": {
+      "description": "Last time the data in the feed was updated in POSIX time.",
+      "type": "integer",
+      "minimum": 1450155600
+    },
+    "ttl": {
+      "description": "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "version": {
+      "description": "GOFS-lite version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
       "enum": [
-        "FeatureCollection"
+        "1.0"
       ]
     },
-    "features": {
-      "type": "array",
-      "items": {
-        "title": "GeoJSON Feature",
-        "type": "object",
-        "required": [
-          "type",
-          "properties",
-          "geometry"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Feature"
-            ]
-          },
-          "id": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
+    "data": {
+      "type": "object",
+      "properties": {
+        "zones": {
+          "$id": "https://geojson.org/schema/FeatureCollection.json",
+          "title": "GeoJSON FeatureCollection",
+          "type": "object",
+          "required": [
+            "type",
+            "features"
+          ],
           "properties": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "object"
-              }
-            ]
-          },
-          "geometry": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "title": "GeoJSON Point",
+            "type": {
+              "type": "string",
+              "enum": [
+                "FeatureCollection"
+              ]
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "title": "GeoJSON Feature",
                 "type": "object",
                 "required": [
                   "type",
-                  "coordinates"
+                  "properties",
+                  "geometry"
                 ],
                 "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "Point"
+                      "Feature"
                     ]
                   },
-                  "coordinates": {
-                    "type": "array",
-                    "minItems": 2,
-                    "items": {
-                      "type": "number"
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON LineString",
-                "type": "object",
-                "required": [
-                  "type",
-                  "coordinates"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "LineString"
-                    ]
-                  },
-                  "coordinates": {
-                    "type": "array",
-                    "minItems": 2,
-                    "items": {
-                      "type": "array",
-                      "minItems": 2,
-                      "items": {
+                  "id": {
+                    "oneOf": [
+                      {
                         "type": "number"
+                      },
+                      {
+                        "type": "string"
                       }
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON Polygon",
-                "type": "object",
-                "required": [
-                  "type",
-                  "coordinates"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "Polygon"
                     ]
                   },
-                  "coordinates": {
-                    "type": "array",
-                    "items": {
-                      "type": "array",
-                      "minItems": 4,
-                      "items": {
-                        "type": "array",
-                        "minItems": 2,
-                        "items": {
-                          "type": "number"
-                        }
+                  "properties": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object"
                       }
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON MultiPoint",
-                "type": "object",
-                "required": [
-                  "type",
-                  "coordinates"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "MultiPoint"
                     ]
                   },
-                  "coordinates": {
-                    "type": "array",
-                    "items": {
-                      "type": "array",
-                      "minItems": 2,
-                      "items": {
-                        "type": "number"
-                      }
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON MultiLineString",
-                "type": "object",
-                "required": [
-                  "type",
-                  "coordinates"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "MultiLineString"
-                    ]
-                  },
-                  "coordinates": {
-                    "type": "array",
-                    "items": {
-                      "type": "array",
-                      "minItems": 2,
-                      "items": {
-                        "type": "array",
-                        "minItems": 2,
-                        "items": {
-                          "type": "number"
-                        }
-                      }
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON MultiPolygon",
-                "type": "object",
-                "required": [
-                  "type",
-                  "coordinates"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "MultiPolygon"
-                    ]
-                  },
-                  "coordinates": {
-                    "type": "array",
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "array",
-                        "minItems": 4,
-                        "items": {
-                          "type": "array",
-                          "minItems": 2,
-                          "items": {
-                            "type": "number"
+                  "geometry": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "title": "GeoJSON Point",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "Point"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
                           }
                         }
-                      }
-                    }
-                  },
-                  "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              },
-              {
-                "title": "GeoJSON GeometryCollection",
-                "type": "object",
-                "required": [
-                  "type",
-                  "geometries"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "GeometryCollection"
-                    ]
-                  },
-                  "geometries": {
-                    "type": "array",
-                    "items": {
-                      "oneOf": [
-                        {
-                          "title": "GeoJSON Point",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "Point"
-                              ]
-                            },
-                            "coordinates": {
+                      },
+                      {
+                        "title": "GeoJSON LineString",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "LineString"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
                               "type": "array",
                               "minItems": 2,
                               "items": {
                                 "type": "number"
                               }
-                            },
-                            "bbox": {
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON Polygon",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "Polygon"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
                               "type": "array",
                               "minItems": 4,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPoint",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiPoint"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
                               "items": {
                                 "type": "number"
                               }
                             }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
                           }
-                        },
-                        {
-                          "title": "GeoJSON LineString",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "LineString"
-                              ]
-                            },
-                            "coordinates": {
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiLineString",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiLineString"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
                               "type": "array",
                               "minItems": 2,
                               "items": {
@@ -339,31 +241,34 @@
                                   "type": "number"
                                 }
                               }
-                            },
-                            "bbox": {
-                              "type": "array",
-                              "minItems": 4,
-                              "items": {
-                                "type": "number"
-                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
                             }
                           }
-                        },
-                        {
-                          "title": "GeoJSON Polygon",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "Polygon"
-                              ]
-                            },
-                            "coordinates": {
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPolygon",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiPolygon"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
                               "type": "array",
                               "items": {
                                 "type": "array",
@@ -376,128 +281,259 @@
                                   }
                                 }
                               }
-                            },
-                            "bbox": {
-                              "type": "array",
-                              "minItems": 4,
-                              "items": {
-                                "type": "number"
-                              }
                             }
-                          }
-                        },
-                        {
-                          "title": "GeoJSON MultiPoint",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "MultiPoint"
-                              ]
-                            },
-                            "coordinates": {
-                              "type": "array",
-                              "items": {
-                                "type": "array",
-                                "minItems": 2,
-                                "items": {
-                                  "type": "number"
-                                }
-                              }
-                            },
-                            "bbox": {
-                              "type": "array",
-                              "minItems": 4,
-                              "items": {
-                                "type": "number"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "title": "GeoJSON MultiLineString",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "MultiLineString"
-                              ]
-                            },
-                            "coordinates": {
-                              "type": "array",
-                              "items": {
-                                "type": "array",
-                                "minItems": 2,
-                                "items": {
-                                  "type": "array",
-                                  "minItems": 2,
-                                  "items": {
-                                    "type": "number"
-                                  }
-                                }
-                              }
-                            },
-                            "bbox": {
-                              "type": "array",
-                              "minItems": 4,
-                              "items": {
-                                "type": "number"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "title": "GeoJSON MultiPolygon",
-                          "type": "object",
-                          "required": [
-                            "type",
-                            "coordinates"
-                          ],
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "MultiPolygon"
-                              ]
-                            },
-                            "coordinates": {
-                              "type": "array",
-                              "items": {
-                                "type": "array",
-                                "items": {
-                                  "type": "array",
-                                  "minItems": 4,
-                                  "items": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "items": {
-                                      "type": "number"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "bbox": {
-                              "type": "array",
-                              "minItems": 4,
-                              "items": {
-                                "type": "number"
-                              }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
                             }
                           }
                         }
-                      ]
-                    }
+                      },
+                      {
+                        "title": "GeoJSON GeometryCollection",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "geometries"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "GeometryCollection"
+                            ]
+                          },
+                          "geometries": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "title": "GeoJSON Point",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "Point"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "title": "GeoJSON LineString",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "LineString"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "title": "GeoJSON Polygon",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "Polygon"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 4,
+                                        "items": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "title": "GeoJSON MultiPoint",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "MultiPoint"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "title": "GeoJSON MultiLineString",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "MultiLineString"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "title": "GeoJSON MultiPolygon",
+                                  "type": "object",
+                                  "required": [
+                                    "type",
+                                    "coordinates"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "MultiPolygon"
+                                      ]
+                                    },
+                                    "coordinates": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "array",
+                                            "minItems": 2,
+                                            "items": {
+                                              "type": "number"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "bbox": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      }
+                    ]
                   },
                   "bbox": {
                     "type": "array",
@@ -508,24 +544,28 @@
                   }
                 }
               }
-            ]
-          },
-          "bbox": {
-            "type": "array",
-            "minItems": 4,
-            "items": {
-              "type": "number"
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "number"
+              }
             }
           }
         }
-      }
-    },
-    "bbox": {
-      "type": "array",
-      "minItems": 4,
-      "items": {
-        "type": "number"
-      }
+      },
+      "required": [
+        "zones"
+      ],
+      "additionalProperties": false
     }
-  }
+  },
+  "additionalProperties": false,
+  "required": [
+    "last_updated",
+    "ttl",
+    "version",
+    "data"
+  ]
 }

--- a/schema/zones.json
+++ b/schema/zones.json
@@ -25,8 +25,7 @@
       "type": "object",
       "properties": {
         "zones": {
-          "$id": "https://geojson.org/schema/FeatureCollection.json",
-          "title": "GeoJSON FeatureCollection",
+          "title": "GeoJSON FeatureCollection with extra fields required by GOFS-lite",
           "type": "object",
           "required": [
             "type",
@@ -45,11 +44,15 @@
                 "title": "GeoJSON Feature",
                 "type": "object",
                 "required": [
+                  "zone_id",
                   "type",
                   "properties",
                   "geometry"
                 ],
                 "properties": {
+                  "zone_id": {
+                    "type": "string"
+                  },
                   "type": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
## What does this PR do?
- Adds missing `"properties: {}"` to `zones.json` example. Previously, if I validated this example (just the content of the `zones` property against the provided schema, it would fail)
![image](https://github.com/user-attachments/assets/bcc5ffdf-7f8d-45d0-9f8d-a50710e9d5d9)

- Updates `zones.json` json-schema to ease document validation. This PR adds multiple required fields (`ttl`, `version`, `last_updated` and `data`). I assumed they are required based on [Output Format](https://github.com/GOFS-lite/GOFS-lite/blob/main/reference.md#output-format) and [zones.json example](https://github.com/GOFS-lite/GOFS-lite/blob/main/reference.md#example-6). Also, it adds an extra property `zone_id` (required), as mentioned [here](https://github.com/GOFS-lite/GOFS-lite/blob/main/reference.md#zonesjson:~:text=%2D%C2%A0%2D-,zone_id,REQUIRED,-ID).

## Result
- The example successfully validated against the schema(and not only the zones property, but the whole document)
![image](https://github.com/user-attachments/assets/891037c7-831a-4b1d-877c-d357bf7b58cf)
![image](https://github.com/user-attachments/assets/8f6ee99e-3619-4a52-b80d-dca4f79eb7d8)

## Notes
The changes I made are not that many, but the GitHub diff doesn't help :(

Glad to hear what you think!