### PR TITLE
Fix invalid examples

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -260,7 +260,7 @@ Field Name | Presence | Type | Description
   "version": "1.0",
   "data": {
     "language": "en",
-    "timezone": "Canada/Toronto",
+    "timezone": "America/Toronto",
     "name": "Example MicroTransit",
     "short_name": "Micro",
     "operator": "MicroTransit, Inc",


### PR DESCRIPTION
Assuming the spec requires RFC 8259 JSON and not something more lenient like JSONC or JSON5

- remove trailing commas
- remove an extra closing curly brace
- add a missing comma
- fix an invalid time zone (the tz database contains `America/Toronto` but the example had `Canada/Toronto`)